### PR TITLE
Containerization revamp

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ RUN echo "${USERNAME}:${PASSWORD}" | chpasswd
 RUN usermod -aG sudo ${USERNAME}
 
 # Change ssh port
-RUN sed -i '/^#\?Port/ { s/^#//; s/Port .*/Port 2522; }' /etc/ssh/sshd_config
+RUN sed -i '/^#\?Port/ { s/^#//; s/Port .*/Port 2522/; }' /etc/ssh/sshd_config
 
 # Colorful prompts ah yee
 RUN sed -i 's/#force_color_prompt=yes/force_color_prompt=yes/' /home/${USERNAME}/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,7 @@ FROM wisniax/ros-rover-base:latest
 # Dockerfile for ROS-JAZZY
 ARG USERNAME='rex'
 ARG PASSWORD='changeme'
+ARG SSH_PORT=22
 
 # Default configuration
 ENV ROS_ENABLE_AUTOSTART=0
@@ -13,8 +14,8 @@ RUN useradd -m -s /bin/bash -g 1000 ${USERNAME}
 RUN echo "${USERNAME}:${PASSWORD}" | chpasswd
 RUN usermod -aG sudo ${USERNAME}
 
-# Change ssh port
-RUN sed -i '/^#\?Port/ { s/^#//; s/Port .*/Port 2522/; }' /etc/ssh/sshd_config
+# Change ssh port and expose it
+RUN sed -i "/^#\?Port/ { s/^#//; s/Port .*/Port ${SSH_PORT}/; }" /etc/ssh/sshd_config
 
 # Colorful prompts ah yee
 RUN sed -i 's/#force_color_prompt=yes/force_color_prompt=yes/' /home/${USERNAME}/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,44 +1,27 @@
-# Use the official image as a parent image
-FROM ros:jazzy-perception
-
-# Default configuration
-ENV ROS_ENABLE_AUTOSTART=0
-ENV ROS_BUILD_ON_STARTUP=on-failure
+FROM wisniax/ros-rover-base:latest
 
 # Dockerfile for ROS-JAZZY
 ARG USERNAME='rex'
 ARG PASSWORD='changeme'
 
-# Update the system
-RUN apt update && apt upgrade -y
-
-# Install random stuff
-RUN DEBIAN_FRONTEND=noninteractive apt install -y git gdb nano curl wget python3 python3-pip net-tools apt-utils nano can-utils ssh libpaho-mqttpp-dev libpaho-mqtt-dev less iputils-ping bc rapidjson-dev iproute2
-
-# Random Stuff
-ENV NOTVISIBLE "in users profile"
-RUN echo "export VISIBLE=now" >> /etc/profile
-RUN ln -sf /usr/share/zoneinfo/Europe/Warsaw /etc/localtime
+# Default configuration
+ENV ROS_ENABLE_AUTOSTART=0
+ENV ROS_BUILD_ON_STARTUP=on-failure
 
 # Create user
 RUN useradd -m -s /bin/bash -g 1000 ${USERNAME}
 RUN echo "${USERNAME}:${PASSWORD}" | chpasswd
 RUN usermod -aG sudo ${USERNAME}
 
-# Disable sudo password auth
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+# Change ssh port
+RUN sed -i '/^#\?Port/ { s/^#//; s/Port .*/Port 2522; }' /etc/ssh/sshd_config
 
 # Colorful prompts ah yee
 RUN sed -i 's/#force_color_prompt=yes/force_color_prompt=yes/' /home/${USERNAME}/.bashrc
 
 # Add important stuff to bashrc
-RUN echo "\nsource /opt/ros/jazzy/setup.bash\nexport ROS_DOMAIN_ID=1\n" >> /home/${USERNAME}/.bashrc
+RUN echo "\nsource /opt/ros/jazzy/setup.bash\nexport ROS_DOMAIN_ID=0\n" >> /home/${USERNAME}/.bashrc
 RUN echo "source ~/raptor_ws/install/setup.bash\n" >> /home/${USERNAME}/.bashrc
-
-RUN apt update && apt upgrade -y
-
-# Environment setup
-RUN apt install -y ros-jazzy-ros2-socketcan libasio-dev libceres-dev ros-jazzy-diagnostic-updater ros-jazzy-diagnostic-updater ros-jazzy-rtcm-msgs ros-jazzy-nmea-msgs
 
 # Pass local directory to the container
 USER ${USERNAME}
@@ -52,7 +35,6 @@ RUN rm -rf /home/${USERNAME}/raptor_ws/log
 RUN rm -rf /home/${USERNAME}/raptor_ws/install
 
 # Fix github 'unsafe' directory
-USER ${USERNAME}
 RUN git config --global --add safe.directory /home/rex/raptor_ws
 
 # Look for submodules

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,6 +37,6 @@
   },
   "containerEnv": {
     //"DISPLAY": "unix:0",
-    "ROS_DOMAIN_ID": "1"
+    "ROS_DOMAIN_ID": "0"
   }
 }

--- a/.devcontainer/docker-entrypoint.sh
+++ b/.devcontainer/docker-entrypoint.sh
@@ -32,7 +32,17 @@ echo "--------------------------------------------------------------------"
 rm -f /tmp/rexlaunch.pgid # remove old PGID file
 
 if service ssh start; then
-    echo "To connect to the container, use ssh rex@localhost -p 2522"
+    # Get the SSH port from the configuration file
+    SSH_PORT_CONFIGURED=$(grep -oP '^Port\s+\K\d+' /etc/ssh/sshd_config)
+
+    if [ -n "$SSH_PORT_CONFIGURED" ]; then
+        echo "To connect to the container, use ssh rex@localhost -p ${SSH_PORT_CONFIGURED}"
+    else
+        echo "SSH service started, but could not determine port from /etc/ssh/sshd_config."
+        echo "Please check the sshd_config file manually."
+    fi
+else
+    echo "SSH service failed to start"
 fi
 
 echo "--------------------------------------------------------------------"

--- a/.devcontainer/rexlaunch.sh
+++ b/.devcontainer/rexlaunch.sh
@@ -1,6 +1,6 @@
 #/bin/sh
 # create a new session (so that all launched nodes share the same PGID, and thus can be bulk-terminated)
-setsid /bin/sh -c '. install/setup.sh && export ROS_DOMAIN_ID=1 && ros2 launch master-launch.yaml >> /tmp/rex_launch.log' &
+setsid /bin/sh -c '. install/setup.sh && export ROS_DOMAIN_ID=0 && ros2 launch master-launch.yaml >> /tmp/rex_launch.log' &
 
 # record the process group ID (PGID)
 PGID=$!

--- a/.github/workflows/build-n-publish.yaml
+++ b/.github/workflows/build-n-publish.yaml
@@ -1,4 +1,4 @@
-name: Build and Publish Raptors Manipulator Docker Image
+name: Build and publish Raptors Manipulator Docker Image
 
 on:
   push:
@@ -8,42 +8,38 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-publish-image:
-    runs-on: ubuntu-latest
+  build-amd64:
+    runs-on: ubuntu-latest # x86-64 runner
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.push-amd64.outputs.digest }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Extract Docker metadata
-        id: meta
+      - name: Extract Docker metadata for AMD64
+        id: meta_amd64
         uses: docker/metadata-action@v5
         with:
           images: alvarobajceps/ros-manipulator
           tags: |
-            # On new version tag (e.g., v1.2.3) -> create v1.2.3
-            type=ref,event=tag
+            # On new version tag (e.g., v1.2.3) -> create v1.2.3-amd64
+            type=ref,event=tag,suffix=-amd64
 
-            # Assign latest only if it's a version tag
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # Assign latest-amd64 only if it's a version tag
+            type=raw,value=latest-amd64,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
-            # On new push to master -> create nightly
-            type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
+            # On new push to master -> create nightly-amd64
+            type=raw,value=nightly-amd64,enable=${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
 
-            # On each PR with master as target -> create pr-<id>
-            # This uses the PR number from the event context directly.
-            type=raw,value=pr-${{ github.event.number }},enable=${{ github.event_name == 'pull_request' }}
+            # On each PR with master as target -> create pr-<id>-amd64
+            type=raw,value=pr-${{ github.event.number }}-amd64,enable=${{ github.event_name == 'pull_request' }}
 
-            # Default: For push to any branch or manual trigger -> create <branch-name>
-            # This will now apply to 'master' pushes (in addition to 'nightly')
-            # and 'workflow_dispatch' builds.
-            type=ref,event=branch
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+            # Default: For push to any branch or manual trigger -> create <branch-name>-amd64
+            type=ref,event=branch,suffix=-amd64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -54,14 +50,110 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push AMD64 Docker image
+        id: push-amd64
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./.devcontainer/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=alvarobajceps/ros-manipulator:buildcache
-          cache-to: type=registry,ref=alvarobajceps/ros-manipulator:buildcache,mode=max
+          tags: ${{ steps.meta_amd64.outputs.tags }}
+          labels: ${{ steps.meta_amd64.outputs.labels }}
+          build-args: |
+            SSH_PORT=2522
+          cache-from: type=registry,ref=alvarobajceps/ros-manipulator:buildcache-amd64
+          cache-to: type=registry,ref=alvarobajceps/ros-manipulator:buildcache-amd64,mode=max
+
+  build-arm64:
+    runs-on: ubuntu-24.04-arm # ARM64 native runner!
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.push-arm64.outputs.digest }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract Docker metadata for ARM64
+        id: meta_arm64
+        uses: docker/metadata-action@v5
+        with:
+          images: alvarobajceps/ros-manipulator
+          tags: |
+            # On new version tag (e.g., v1.2.3) -> create v1.2.3-arm64
+            type=ref,event=tag,suffix=-arm64
+
+            # Assign latest-arm64 only if it's a version tag
+            type=raw,value=latest-arm64,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+            # On new push to master -> create nightly-arm64
+            type=raw,value=nightly-arm64,enable=${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
+
+            # On each PR with master as target -> create pr-<id>-arm64
+            type=raw,value=pr-${{ github.event.number }}-arm64,enable=${{ github.event_name == 'pull_request' }}
+
+            # Default: For push to any branch or manual trigger -> create <branch-name>-arm64
+            type=ref,event=branch,suffix=-arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push ARM64 Docker image
+        id: push-arm64
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./.devcontainer/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta_arm64.outputs.tags }}
+          labels: ${{ steps.meta_arm64.outputs.labels }}
+          build-args: |
+            SSH_PORT=2522
+          cache-from: type=registry,ref=alvarobajceps/ros-manipulator:buildcache-arm64
+          cache-to: type=registry,ref=alvarobajceps/ros-manipulator:buildcache-arm64,mode=max
+
+  create-manifest:
+    runs-on: ubuntu-latest # Can run on x86-64 runner
+    needs: [build-amd64, build-arm64] # Ensures both arch-specific builds complete
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata for combined manifest
+        id: meta_combined
+        uses: docker/metadata-action@v5
+        with:
+          images: alvarobajceps/ros-manipulator
+          tags: |
+            # Original tags logic for the multi-arch manifest
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
+            type=raw,value=pr-${{ github.event.number }},enable=${{ github.event_name == 'pull_request' }}
+            type=ref,event=branch
+
+      - name: Create and push multi-arch manifest
+        uses: int128/docker-manifest-create-action@v2
+        with:
+          tags: ${{ steps.meta_combined.outputs.tags }}
+          sources: |
+            alvarobajceps/ros-manipulator@${{ needs.build-amd64.outputs.digest }}
+            alvarobajceps/ros-manipulator@${{ needs.build-arm64.outputs.digest }}
+          index-annotations: ${{ steps.meta_combined.outputs.labels }}

--- a/.github/workflows/build-n-test.yaml
+++ b/.github/workflows/build-n-test.yaml
@@ -1,0 +1,34 @@
+name: Build image and run tests (soonTM).
+
+on:
+  push:
+    branches: [ "master" ]
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  build-amd64:
+    runs-on: ubuntu-latest # x86-64 runner
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build AMD64 Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./.devcontainer/Dockerfile
+          platforms: linux/amd64
+          build-args: |
+            SSH_PORT=2522
+          push: false
+          cache-from: type=registry,ref=wisniax/ros-core:buildcache-amd64

--- a/.github/workflows/build-n-test.yaml
+++ b/.github/workflows/build-n-test.yaml
@@ -31,4 +31,4 @@ jobs:
           build-args: |
             SSH_PORT=2522
           push: false
-          cache-from: type=registry,ref=wisniax/ros-core:buildcache-amd64
+          cache-from: type=registry,ref=alvarobajceps/ros-manipulator:buildcache-amd64

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 # Container features
 ## SSH into the container
 `ssh rex@[ip-here] -p [port-here]`
-e.g. `ssh rex@localhost -p 2521`
+e.g. `ssh rex@localhost -p 2522`
 
 ## Build the repo
 > Obviously only works from inside the container ;)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,13 @@
-networks:
-  default:
-    name: ros-core-network
-    external: true
-
 services:
   ros-manipulator:
     build:
       context: .
       dockerfile: ./.devcontainer/Dockerfile
-    image: alvarobajceps/ros-manipulator
+    image: alvarobajceps/ros-manipulator:latest
     container_name: ros-manipulator
     hostname: ros-manipulator
+    network_mode: "host"
     init: true
-    ports:
-      - "2522:22"
     environment:
       - TZ=Europe/Warsaw
       - ROS_ENABLE_AUTOSTART=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: ./.devcontainer/Dockerfile
+      args:
+        SSH_PORT: 2522
     image: alvarobajceps/ros-manipulator:latest
     container_name: ros-manipulator
     hostname: ros-manipulator

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: ./.devcontainer/Dockerfile
       args:
         SSH_PORT: 2522
-    image: alvarobajceps/ros-manipulator:latest
+    image: alvarobajceps/ros-manipulator:nightly
     container_name: ros-manipulator
     hostname: ros-manipulator
     network_mode: "host"


### PR DESCRIPTION
Docker image is now on network host
ROS_DOMAIN_ID 1 &rarr; 0
[(ssh port selection)](https://github.com/AlvaroBajceps/manipulator_ws/commit/565c8cd351c6119229a05740d20fe1629fab0dad) based on latest ros-core image
[Updated GH build action](https://github.com/AlvaroBajceps/manipulator_ws/commit/5da825b14994d058c6eeba6f8c204ab4cdda880c) so that it's blazing fast there too
[Changed default image to nightly (latest master) to avoid confusion](https://github.com/AlvaroBajceps/manipulator_ws/commit/a02d7cc2b799cc9880a9e8931221e35ab6df17ff)
Bonus: [GH action to Build image and run tests (soonTM)](https://github.com/AlvaroBajceps/manipulator_ws/commit/8d344ce80323e313eac2370ddfed0f54f953d6b2)